### PR TITLE
Readme Güncellemesi

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ You can download the pre-built binaries from the [releases](https://github.com/u
 
 1) Install Go on your system
 
-2) Run: `go get -u github.com/utkusen/wholeaked`
+2) Run: `go install github.com/utkusen/wholeaked@latest`
 
 ## Installing Dependencies
 


### PR DESCRIPTION
Merhaba, yeni toolunuz harika olmuş, tebrikler :)

Go 1.17 sürümünden itibaren `go get` kullanımdan kaldırılmıştır. Onun yerine `go install pkg@version` kullanılmaktadır. Toolu yükleyenlerin hatayla karşılaşmaması için kurulum komutunu `go install github.com/utkusen/wholeaked@latest` olarak değiştirmek doğru olacaktır.
Detaylı bilgi için: https://go.dev/doc/go-get-install-deprecation

İyi çalışmalar dilerim.