### PR TITLE
Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+#goland
+.idea/*

--- a/main.go
+++ b/main.go
@@ -181,9 +181,7 @@ func detectWatermarkPDF(file, signature string) bool {
 }
 
 func addWatermarkPDF(file, signature string) {
-	onTop := false
-	update := false
-	wm, _ := api.TextWatermark(signature, "sc:.9, rot:0, mo:1, op:0", onTop, update, pdfcpu.POINTS)
+	wm, _ := api.TextWatermark(signature, "sc:.9, rot:0, mo:1, op:0", false, false, pdfcpu.POINTS)
 	api.AddWatermarksFile(file, "", nil, wm, nil)
 }
 

--- a/main.go
+++ b/main.go
@@ -698,8 +698,8 @@ func sendWithSendgrid(toName, toEmail, fromName, fromEmail, subject, bodyFile, c
 					fmt.Println(err)
 					os.Exit(1)
 				}
-				defer f.Close()
 				contentType := GetFileContentType(f)
+				f.Close()
 				attachmentFile := mail.NewAttachment()
 				dat, err := ioutil.ReadFile(attachment)
 				if err != nil {


### PR DESCRIPTION
1. Added .gitignore for untrucked file
2. Updated defer usage which may cause resource leak. The resources created in the loop cannot be closed until the function exits, so they will accumulate until then.
3. Always false expression.